### PR TITLE
Test Python 3.8 and 3.9-dev, don't test PyPy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ dist: xenial
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
 python:
- - pypy3
  - 3.7
  - 3.6
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ dist: xenial
 # Supported CPython versions:
 # https://en.wikipedia.org/wiki/CPython#Version_history
 python:
+ - 3.9-dev
+ - 3.8
  - 3.7
  - 3.6
 


### PR DESCRIPTION
PyPy3 can't build a wheel for typed-ast, a test dependency of Black:

```console
$ pip install -U black flake8
Collecting black
  Downloading black-19.10b0-py36-none-any.whl (97 kB)
Collecting flake8
  Downloading flake8-3.7.9-py2.py3-none-any.whl (69 kB)
Collecting click>=6.5
  Downloading Click-7.0-py2.py3-none-any.whl (81 kB)
Requirement already satisfied, skipping upgrade: attrs>=18.1.0 in /home/travis/virtualenv/pypy3.6-7.1.1/site-packages (from black) (19.1.0)
Collecting appdirs
  Downloading appdirs-1.4.3-py2.py3-none-any.whl (12 kB)
Collecting toml>=0.9.4
  Downloading toml-0.10.0-py2.py3-none-any.whl (25 kB)
Collecting typed-ast>=1.4.0
  Downloading typed_ast-1.4.1.tar.gz (208 kB)
Collecting regex
  Downloading regex-2020.2.20.tar.gz (681 kB)
Collecting pathspec<1,>=0.6
  Downloading pathspec-0.7.0-py2.py3-none-any.whl (25 kB)
Collecting entrypoints<0.4.0,>=0.3.0
  Downloading entrypoints-0.3-py2.py3-none-any.whl (11 kB)
Collecting pyflakes<2.2.0,>=2.1.0
  Downloading pyflakes-2.1.1-py2.py3-none-any.whl (59 kB)
Collecting pycodestyle<2.6.0,>=2.5.0
  Downloading pycodestyle-2.5.0-py2.py3-none-any.whl (51 kB)
Collecting mccabe<0.7.0,>=0.6.0
  Downloading mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Building wheels for collected packages: typed-ast, regex
  Building wheel for typed-ast (setup.py) ... error
  ERROR: Command errored out with exit status 1:
   command: /home/travis/virtualenv/pypy3.6-7.1.1/bin/pypy3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yg3a_pa1/typed-ast/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yg3a_pa1/typed-ast/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-zdit2yj5
       cwd: /tmp/pip-install-yg3a_pa1/typed-ast/
  Complete output (31 lines):
  running bdist_wheel
  running build
  running build_py
  creating build
  creating build/lib.linux-x86_64-3.6
  creating build/lib.linux-x86_64-3.6/typed_ast
  copying typed_ast/ast27.py -> build/lib.linux-x86_64-3.6/typed_ast
  copying typed_ast/conversions.py -> build/lib.linux-x86_64-3.6/typed_ast
  copying typed_ast/ast3.py -> build/lib.linux-x86_64-3.6/typed_ast
  copying typed_ast/__init__.py -> build/lib.linux-x86_64-3.6/typed_ast
  package init file 'ast3/tests/__init__.py' not found (or not a regular file)
  creating build/lib.linux-x86_64-3.6/typed_ast/tests
  copying ast3/tests/test_basics.py -> build/lib.linux-x86_64-3.6/typed_ast/tests
  running build_ext
  building '_ast27' extension
  creating build/temp.linux-x86_64-3.6
  creating build/temp.linux-x86_64-3.6/ast27
  creating build/temp.linux-x86_64-3.6/ast27/Parser
  creating build/temp.linux-x86_64-3.6/ast27/Python
  creating build/temp.linux-x86_64-3.6/ast27/Custom
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/acceler.c -o build/temp.linux-x86_64-3.6/ast27/Parser/acceler.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/bitset.c -o build/temp.linux-x86_64-3.6/ast27/Parser/bitset.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/grammar.c -o build/temp.linux-x86_64-3.6/ast27/Parser/grammar.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/grammar1.c -o build/temp.linux-x86_64-3.6/ast27/Parser/grammar1.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/node.c -o build/temp.linux-x86_64-3.6/ast27/Parser/node.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/parser.c -o build/temp.linux-x86_64-3.6/ast27/Parser/parser.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/parsetok.c -o build/temp.linux-x86_64-3.6/ast27/Parser/parsetok.o
  gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/tokenizer.c -o build/temp.linux-x86_64-3.6/ast27/Parser/tokenizer.o
  ast27/Parser/tokenizer.c:17:20: fatal error: codecs.h: No such file or directory
  compilation terminated.
  error: command 'gcc' failed with exit status 1
  ----------------------------------------
  ERROR: Failed building wheel for typed-ast
  Running setup.py clean for typed-ast
  Building wheel for regex (setup.py) ... done
  Created wheel for regex: filename=regex-2020.2.20-pp371-pypy3_71-linux_x86_64.whl size=289360 sha256=0b620e93e4632dffdcd593466a4b739a3af490dc893db0c2879572c89c2f7765
  Stored in directory: /home/travis/.cache/pip/wheels/c6/d7/f9/1fb97bd4b259537c78ce55bfa816a3b3c486c8cd4f21a2d6f7
Successfully built regex
Failed to build typed-ast
Installing collected packages: click, appdirs, toml, typed-ast, regex, pathspec, black, entrypoints, pyflakes, pycodestyle, mccabe, flake8
    Running setup.py install for typed-ast ... error
    ERROR: Command errored out with exit status 1:
     command: /home/travis/virtualenv/pypy3.6-7.1.1/bin/pypy3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yg3a_pa1/typed-ast/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yg3a_pa1/typed-ast/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-165bplut/install-record.txt --single-version-externally-managed --compile --install-headers /home/travis/virtualenv/pypy3.6-7.1.1/include/site/python3.6/typed-ast
         cwd: /tmp/pip-install-yg3a_pa1/typed-ast/
    Complete output (31 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.6
    creating build/lib.linux-x86_64-3.6/typed_ast
    copying typed_ast/ast27.py -> build/lib.linux-x86_64-3.6/typed_ast
    copying typed_ast/conversions.py -> build/lib.linux-x86_64-3.6/typed_ast
    copying typed_ast/ast3.py -> build/lib.linux-x86_64-3.6/typed_ast
    copying typed_ast/__init__.py -> build/lib.linux-x86_64-3.6/typed_ast
    package init file 'ast3/tests/__init__.py' not found (or not a regular file)
    creating build/lib.linux-x86_64-3.6/typed_ast/tests
    copying ast3/tests/test_basics.py -> build/lib.linux-x86_64-3.6/typed_ast/tests
    running build_ext
    building '_ast27' extension
    creating build/temp.linux-x86_64-3.6
    creating build/temp.linux-x86_64-3.6/ast27
    creating build/temp.linux-x86_64-3.6/ast27/Parser
    creating build/temp.linux-x86_64-3.6/ast27/Python
    creating build/temp.linux-x86_64-3.6/ast27/Custom
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/acceler.c -o build/temp.linux-x86_64-3.6/ast27/Parser/acceler.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/bitset.c -o build/temp.linux-x86_64-3.6/ast27/Parser/bitset.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/grammar.c -o build/temp.linux-x86_64-3.6/ast27/Parser/grammar.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/grammar1.c -o build/temp.linux-x86_64-3.6/ast27/Parser/grammar1.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/node.c -o build/temp.linux-x86_64-3.6/ast27/Parser/node.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/parser.c -o build/temp.linux-x86_64-3.6/ast27/Parser/parser.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/parsetok.c -o build/temp.linux-x86_64-3.6/ast27/Parser/parsetok.o
    gcc -pthread -DNDEBUG -O2 -fPIC -Iast27/Include -I/opt/python/pypy3.6-7.1.1/include -c ast27/Parser/tokenizer.c -o build/temp.linux-x86_64-3.6/ast27/Parser/tokenizer.o
    ast27/Parser/tokenizer.c:17:20: fatal error: codecs.h: No such file or directory
    compilation terminated.
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /home/travis/virtualenv/pypy3.6-7.1.1/bin/pypy3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yg3a_pa1/typed-ast/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yg3a_pa1/typed-ast/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-165bplut/install-record.txt --single-version-externally-managed --compile --install-headers /home/travis/virtualenv/pypy3.6-7.1.1/include/site/python3.6/typed-ast Check the logs for full command output.
The command "pip install -U black flake8" failed and exited with 1 during .
```

https://travis-ci.org/hugovk/gutenberg-metadata/jobs/655095476